### PR TITLE
Rename instances of connectivity-monitor to connectivity-exporter

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Gardener connectivity monitor
+Upstream-Name: Gardener connectivity exporter
 Upstream-Contact: The Gardener project <gardener@googlegroups.com>
-Source: https://github.com/gardener/connectivity-monitor
+Source: https://github.com/gardener/connectivity-exporter
 Comment:
 
 # --------------------------------------------------
@@ -13,7 +13,7 @@ Files:
   **/.gitignore
   **/go.mod
   **/go.sum
-  charts/connectivity-monitor/dashboards/*.json
+  charts/connectivity-exporter/dashboards/*.json
 Copyright: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 License: Apache-2.0
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We can distinguish multiple failure types:
 
 - There is no network connectivity to the api server.
 
-  The focus of this connectivity-monitor component.
+  The focus of this connectivity-exporter component.
 
   New TCP connections to the kubernetes api server are observed to confirm that
   all the components along the network path to the kubernetes api server, and
@@ -48,17 +48,17 @@ We can distinguish multiple failure types:
   connection tracking tables, or the reverse proxy might be overloaded to accept
   any new connections.
   The mundane failure case that there are no running api server processes is
-  also covered by the connectivity monitor.
+  also covered by the connectivity-exporter.
 
 - The api server reports an internal server error.
 
-  Detecting this failure type is not feasible for the connectivity-monitor
+  Detecting this failure type is not feasible for the connectivity-exporter
   component; it can be achieved by processing the access logs of the api server.
 
   The failure cases when the connection is successfully established, but the api
   server detects and returns a internal server failure (4xx - user error, 5xx -
   internal error) are considered as successful connection attempts, hence the
-  connectivity monitor yields an upper bound for meaningful availability.
+  connectivity-exporter yields an upper bound for meaningful availability.
   This situations can be detected on the server side, by parsing the access
   logs, knowing that due to the successful connections we can expect to find
   matching access logs.

--- a/charts/connectivity-exporter/values.yaml
+++ b/charts/connectivity-exporter/values.yaml
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Default values for connectivity-monitor.
+# Default values for connectivity-exporter.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
 image:
   registry: ghcr.io
-  name: gardener/connectivity-monitor
+  name: gardener/connectivity-exporter
   tag: main
   pullPolicy: Always
 

--- a/connectivity-exporter/Dockerfile
+++ b/connectivity-exporter/Dockerfile
@@ -15,4 +15,4 @@ COPY --from=builder /build/bin/connectivity-exporter /bin/connectivity-exporter
 ENTRYPOINT [ "/bin/connectivity-exporter" ]
 
 # Example command:
-# docker run --privileged --net=host -ti --rm ghcr.io/gardener/connectivity-monitor:main -r 0.0.0.0/0 -p 443
+# docker run --privileged --net=host -ti --rm ghcr.io/gardener/connectivity-exporter:main -r 0.0.0.0/0 -p 443

--- a/connectivity-exporter/Makefile
+++ b/connectivity-exporter/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 REGISTRY ?= ghcr.io
-IMAGE_NAME ?= gardener/connectivity-monitor
+IMAGE_NAME ?= gardener/connectivity-exporter
 IMAGE_TAG ?= main
 
 all: build

--- a/connectivity-exporter/packet/c/types.h
+++ b/connectivity-exporter/packet/c/types.h
@@ -99,7 +99,6 @@ struct tuple_data_t {
   } state;
   char sni[TLS_MAX_SERVER_NAME_LEN];
   // The following two fields cause clang to crash when set to __u16.
-  // More info: https://github.tools.sap/kubernetes/connectivity-monitor/pull/109#discussion_r453913
   __u64 num_packets;
   __u64 total_data_bytes;
   __u64 ticker_clock_first_packet;

--- a/docs/ebpf.md
+++ b/docs/ebpf.md
@@ -1,4 +1,4 @@
-# New eBPF architecture for connectivity-monitor
+# New eBPF architecture for connectivity-exporter
 
 ![Flows of execution](flows.png "Flows of execution")
 

--- a/docs/localsetup.md
+++ b/docs/localsetup.md
@@ -35,6 +35,6 @@ ubuntu@vm$ echo 'PATH=$PATH:/usr/lib/go-1.18/bin' >> ~/.bashrc; source ~/.bashrc
 ### Compile the program
 
 ```shell
-ubuntu@vm$ cd /to/mount/directory/connectivity-monitor
+ubuntu@vm$ cd /to/mount/directory/connectivity-exporter
 ubuntu@vm$ make build
 ```


### PR DESCRIPTION
Cleanup any renaming instances of connectivity-monitor and replace them with connectivity-exporter. Done after renaming the repository to gardener/connectivity-exporter.