### PR TITLE
Increase the rule evaluation interval to 30s

### DIFF
--- a/charts/connectivity-exporter/rules/error-budget.yaml
+++ b/charts/connectivity-exporter/rules/error-budget.yaml
@@ -5,7 +5,7 @@
 groups:
 
 - name: error_budget
-  interval: 10s
+  interval: 30s
   rules:
 
   - record: service:sli_seconds
@@ -13,8 +13,8 @@ groups:
     expr: |
       max by (sni, kind) (
         clamp_max(
-          rate(connectivity_exporter_seconds_total{kind=~"failed|active_failed"}[1m]) * 10,
-          10
+          rate(connectivity_exporter_seconds_total{kind=~"failed|active_failed"}[2m]) * 30,
+          30
         )
       )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* Evaluation interval is now the same as the scrape interval
* Adjust the rate to 2m

