### PR TITLE
Reset the weekly metrics on Sundays at midnight

### DIFF
--- a/charts/connectivity-exporter/rules/error-budget.yaml
+++ b/charts/connectivity-exporter/rules/error-budget.yaml
@@ -48,9 +48,12 @@ groups:
       + ignoring(week) group_right
       count_values without() ("week",
         floor(
-          timestamp(
-            service:sli_seconds
-          ) / 60 / 60 / 24 / 7
+          (
+            timestamp(
+              service:sli_seconds
+            ) - 4 * 24 * 60 * 60
+          )
+          / 60 / 60 / 24 / 7
         )
       ) * 0
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, they were reset on Thursdays at midnight,
because the start of the unix epoch time, January 1, 1970 was a Thursday.

**Special notes for your reviewer**:

May 9, 2022 is a Monday.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/23032437/167806707-82688d94-5eb1-421c-abf8-981f7bc9b4e0.png">
